### PR TITLE
Add MfxAttributeAttachment, MfxAttributeSemantic enums to C++ SDK

### DIFF
--- a/CppPluginSupport/src/MfxAttribute.cpp
+++ b/CppPluginSupport/src/MfxAttribute.cpp
@@ -8,7 +8,7 @@ MfxAttribute::MfxAttribute(const MfxHost& host, OfxPropertySetHandle properties)
 	, m_properties(properties)
 {}
 
-MfxAttributeType MfxAttribute::mfxAttrAsEnum(const char* mfxType)
+MfxAttributeType MfxAttribute::mfxAttrTypeAsEnum(const char* mfxType)
 {
     if (0 == strcmp(mfxType, kOfxMeshAttribTypeUByte)) {
         return MfxAttributeType::UByte;
@@ -23,7 +23,44 @@ MfxAttributeType MfxAttribute::mfxAttrAsEnum(const char* mfxType)
     return MfxAttributeType::Unknown;
 }
 
-const char *MfxAttribute::mfxAttrAsString(MfxAttributeType mfxType) {
+MfxAttributeAttachment MfxAttribute::mfxAttrAttachmentAsEnum(const char *mfxAttachment) {
+    if (0 == strcmp(mfxAttachment, kOfxMeshAttribPoint)) {
+        return MfxAttributeAttachment::Point;
+    }
+    if (0 == strcmp(mfxAttachment, kOfxMeshAttribVertex)) {
+        return MfxAttributeAttachment::Vertex;
+    }
+    if (0 == strcmp(mfxAttachment, kOfxMeshAttribFace)) {
+        return MfxAttributeAttachment::Face;
+    }
+    if (0 == strcmp(mfxAttachment, kOfxMeshAttribMesh)) {
+        return MfxAttributeAttachment::Mesh;
+    }
+    printf("Warning: unknown attribute attachment: %s\n", mfxAttachment);
+    return MfxAttributeAttachment::Unknown;
+}
+
+MfxAttributeSemantic MfxAttribute::mfxAttrSemanticAsEnum(const char *mfxSemantic) {
+    if (mfxSemantic == NULL) {
+        return MfxAttributeSemantic::None;
+    }
+    if (0 == strcmp(mfxSemantic, kOfxMeshAttribSemanticColor)) {
+        return MfxAttributeSemantic::Color;
+    }
+    if (0 == strcmp(mfxSemantic, kOfxMeshAttribSemanticNormal)) {
+        return MfxAttributeSemantic::Normal;
+    }
+    if (0 == strcmp(mfxSemantic, kOfxMeshAttribSemanticTextureCoordinate)) {
+        return MfxAttributeSemantic::TextureCoordinate;
+    }
+    if (0 == strcmp(mfxSemantic, kOfxMeshAttribSemanticWeight)) {
+        return MfxAttributeSemantic::Weight;
+    }
+    printf("Warning: unknown attribute semantic: %s\n", mfxSemantic);
+    return MfxAttributeSemantic::Unknown;
+}
+
+const char *MfxAttribute::mfxAttrTypeAsString(MfxAttributeType mfxType) {
     switch (mfxType) {
         case MfxAttributeType::UByte:
             return kOfxMeshAttribTypeUByte;
@@ -34,6 +71,42 @@ const char *MfxAttribute::mfxAttrAsString(MfxAttributeType mfxType) {
         case MfxAttributeType::Unknown:
         default:
             printf("Warning: unknown attribute type: %d\n", (int)mfxType);
+            return "";
+    }
+}
+
+const char *MfxAttribute::mfxAttrAttachmentAsString(MfxAttributeAttachment mfxAttachment) {
+    switch (mfxAttachment) {
+        case MfxAttributeAttachment::Point:
+            return kOfxMeshAttribPoint;
+        case MfxAttributeAttachment::Vertex:
+            return kOfxMeshAttribVertex;
+        case MfxAttributeAttachment::Face:
+            return kOfxMeshAttribFace;
+        case MfxAttributeAttachment::Mesh:
+            return kOfxMeshAttribMesh;
+        case MfxAttributeAttachment::Unknown:
+        default:
+            printf("Warning: unknown attribute attachment: %d\n", (int)mfxAttachment);
+        return "";
+    }
+}
+
+const char *MfxAttribute::mfxAttrSemanticAsString(MfxAttributeSemantic mfxSemantic) {
+    switch (mfxSemantic) {
+        case MfxAttributeSemantic::None:
+            return NULL;
+        case MfxAttributeSemantic::Weight:
+            return kOfxMeshAttribSemanticWeight;
+        case MfxAttributeSemantic::TextureCoordinate:
+            return kOfxMeshAttribSemanticTextureCoordinate;
+        case MfxAttributeSemantic::Normal:
+            return kOfxMeshAttribSemanticNormal;
+        case MfxAttributeSemantic::Color:
+            return kOfxMeshAttribSemanticColor;
+        case MfxAttributeSemantic::Unknown:
+        default:
+            printf("Warning: unknown attribute semantic: %d\n", (int)mfxSemantic);
             return "";
     }
 }
@@ -105,12 +178,12 @@ void MfxAttribute::FetchProperties(MfxAttributeProps& props)
     MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshAttribPropComponentCount, 0, &props.componentCount));
     MFX_ENSURE(propertySuite->propGetPointer(m_properties, kOfxMeshAttribPropData, 0, (void**)&props.data));
     MFX_ENSURE(propertySuite->propGetInt(m_properties, kOfxMeshAttribPropIsOwner, 0, &isOwner));
-    props.type = mfxAttrAsEnum(type);
+    props.type = mfxAttrTypeAsEnum(type);
     props.isOwner = (bool)isOwner;
 }
 
 void MfxAttribute::SetProperties(const MfxAttributeProps &props) {
-    const char* type = mfxAttrAsString(props.type);
+    const char* type = mfxAttrTypeAsString(props.type);
 
     MFX_ENSURE(propertySuite->propSetString(m_properties, kOfxMeshAttribPropType, 0, type));
     MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxMeshAttribPropStride, 0, props.stride));

--- a/CppPluginSupport/src/MfxAttribute.h
+++ b/CppPluginSupport/src/MfxAttribute.h
@@ -10,17 +10,38 @@ struct MfxAttribute : public MfxBase
 {
 private:
 	friend class MfxMesh;
+	friend class MfxInputDef;
 	MfxAttribute(const MfxHost& host, OfxPropertySetHandle properties);
 
 	/**
 	 * Convert a type string from MeshEffect API to its local enum counterpart
 	 */
-	static MfxAttributeType mfxAttrAsEnum(const char* mfxType);
+	static MfxAttributeType mfxAttrTypeAsEnum(const char* mfxType);
+
+    /**
+     * Convert attribute attachment string from MeshEffect API to its local enum counterpart
+     */
+    static MfxAttributeAttachment mfxAttrAttachmentAsEnum(const char* mfxAttachment);
+
+    /**
+	 * Convert attribute semantic string from MeshEffect API to its local enum counterpart
+	 */
+    static MfxAttributeSemantic mfxAttrSemanticAsEnum(const char* mfxSemantic);
 
     /**
      * Convert local typestring enum to a type string from MeshEffect API
      */
-    static const char* mfxAttrAsString(MfxAttributeType mfxType);
+    static const char* mfxAttrTypeAsString(MfxAttributeType mfxType);
+
+    /**
+     * Convert local attachment enum to an attachment string from MeshEffect API
+     */
+    static const char* mfxAttrAttachmentAsString(MfxAttributeAttachment mfxAttachment);
+
+    /**
+     * Convert local semantic enum to a semantic string from MeshEffect API
+     */
+    static const char* mfxAttrSemanticAsString(MfxAttributeSemantic mfxSemantic);
 
 	/**
 	 * Copy attribute and try to cast. If number of component is different,

--- a/CppPluginSupport/src/MfxAttributeProps.h
+++ b/CppPluginSupport/src/MfxAttributeProps.h
@@ -7,6 +7,23 @@ enum class MfxAttributeType {
     Float,
 };
 
+enum class MfxAttributeAttachment {
+    Unknown = -1,
+    Point,
+    Vertex,
+    Face,
+    Mesh,
+};
+
+enum class MfxAttributeSemantic {
+    Unknown = -1,
+    None,
+    TextureCoordinate,
+    Normal,
+    Color,
+    Weight,
+};
+
 /**
  * Mfx*Props classes are a little different: for caching and convenience, they
  * store some data and care must be taken not to copy it around too much

--- a/CppPluginSupport/src/MfxInputDef.cpp
+++ b/CppPluginSupport/src/MfxInputDef.cpp
@@ -41,6 +41,31 @@ MfxInputDef& MfxInputDef::RequestMeshAttribute(const char* name, int componentCo
 	return RequestAttribute(kOfxMeshAttribMesh, name, componentCount, type, semantic, mandatory);
 }
 
+MfxInputDef& MfxInputDef::RequestAttribute(MfxAttributeAttachment attachment, const char *name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
+    return RequestAttribute(MfxAttribute::mfxAttrAttachmentAsString(attachment),
+                            name,
+                            componentCount,
+                            MfxAttribute::mfxAttrTypeAsString(type),
+                            MfxAttribute::mfxAttrSemanticAsString(semantic),
+                            mandatory);
+}
+
+MfxInputDef& MfxInputDef::RequestPointAttribute(const char *name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
+    return RequestAttribute(MfxAttributeAttachment::Point, name, componentCount, type, semantic, mandatory);
+}
+
+MfxInputDef& MfxInputDef::RequestVertexAttribute(const char *name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
+    return RequestAttribute(MfxAttributeAttachment::Vertex, name, componentCount, type, semantic, mandatory);;
+}
+
+MfxInputDef& MfxInputDef::RequestFaceAttribute(const char *name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
+    return RequestAttribute(MfxAttributeAttachment::Face, name, componentCount, type, semantic, mandatory);;
+}
+
+MfxInputDef& MfxInputDef::RequestMeshAttribute(const char *name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory) {
+    return RequestAttribute(MfxAttributeAttachment::Mesh, name, componentCount, type, semantic, mandatory);;
+}
+
 MfxInputDef& MfxInputDef::RequestGeometry(bool request)
 {
 	MFX_ENSURE(propertySuite->propSetInt(m_properties, kOfxInputPropRequestGeometry, 0, request ? 1 : 0));

--- a/CppPluginSupport/src/MfxInputDef.h
+++ b/CppPluginSupport/src/MfxInputDef.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "MfxBase.h"
-
+#include "MfxAttribute.h"
 
 #include "ofxCore.h"
 #include "ofxMeshEffect.h"
@@ -45,6 +45,13 @@ public:
 	MfxInputDef & RequestVertexAttribute(const char* name, int componentCount, const char* type, const char* semantic, bool mandatory);
 	MfxInputDef & RequestFaceAttribute(const char* name, int componentCount, const char* type, const char* semantic, bool mandatory);
 	MfxInputDef & RequestMeshAttribute(const char* name, int componentCount, const char* type, const char* semantic, bool mandatory);
+
+    MfxInputDef & RequestAttribute(MfxAttributeAttachment attachment, const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
+
+    MfxInputDef & RequestPointAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
+    MfxInputDef & RequestVertexAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
+    MfxInputDef & RequestFaceAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
+    MfxInputDef & RequestMeshAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic, bool mandatory);
 
 	/**
 	 * Set the geometry matrix dependency flag of this input.

--- a/CppPluginSupport/src/MfxMesh.cpp
+++ b/CppPluginSupport/src/MfxMesh.cpp
@@ -40,6 +40,10 @@ MfxAttribute MfxMesh::GetAttribute(const char* attachment, const char* name)
 	return MfxAttribute(host(), attribute);
 }
 
+MfxAttribute MfxMesh::GetAttribute(MfxAttributeAttachment attachment, const char *name) {
+    return GetAttribute(MfxAttribute::mfxAttrAttachmentAsString(attachment), name);
+}
+
 MfxAttribute MfxMesh::GetPointAttribute(const char* name)
 {
 	return GetAttribute(kOfxMeshAttribPoint, name);
@@ -72,6 +76,10 @@ bool MfxMesh::HasAttribute(const char* attachment, const char* name)
     } else {
         throw MfxSuiteException(status, "meshEffectSuite->meshGetAttribute(m_mesh, attachment, name, &attribute)");
     }
+}
+
+bool MfxMesh::HasAttribute(MfxAttributeAttachment attachment, const char* name) {
+    return HasAttribute(MfxAttribute::mfxAttrAttachmentAsString(attachment), name);
 }
 
 bool MfxMesh::HasPointAttribute(const char* name)
@@ -127,6 +135,30 @@ MfxAttribute MfxMesh::AddFaceAttribute(const char* name, int componentCount, con
 MfxAttribute MfxMesh::AddMeshAttribute(const char* name, int componentCount, const char* type, const char* semantic)
 {
 	return AddAttribute(kOfxMeshAttribMesh, name, componentCount, type, semantic);
+}
+
+MfxAttribute MfxMesh::AddAttribute(MfxAttributeAttachment attachment, const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic) {
+    return AddAttribute(MfxAttribute::mfxAttrAttachmentAsString(attachment),
+                        name,
+                        componentCount,
+                        MfxAttribute::mfxAttrTypeAsString(type),
+                        MfxAttribute::mfxAttrSemanticAsString(semantic));
+}
+
+MfxAttribute MfxMesh::AddPointAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic) {
+    return AddAttribute(MfxAttributeAttachment::Point, name, componentCount, type, semantic);
+}
+
+MfxAttribute MfxMesh::AddVertexAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic) {
+    return AddAttribute(MfxAttributeAttachment::Vertex, name, componentCount, type, semantic);
+}
+
+MfxAttribute MfxMesh::AddFaceAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic) {
+    return AddAttribute(MfxAttributeAttachment::Face, name, componentCount, type, semantic);
+}
+
+MfxAttribute MfxMesh::AddMeshAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic) {
+    return AddAttribute(MfxAttributeAttachment::Mesh, name, componentCount, type, semantic);
 }
 
 void MfxMesh::Allocate(int pointCount, int vertCount, int faceCount, bool noLooseEdge, int constantFaceCount)

--- a/CppPluginSupport/src/MfxMesh.h
+++ b/CppPluginSupport/src/MfxMesh.h
@@ -46,7 +46,8 @@ public:
 	 * `Get*Attribute` methods are shortcuts for the different values allowed
 	 * for the `attachment` argument.
 	 */
-	MfxAttribute GetAttribute(const char* attachment, const char* name);
+    MfxAttribute GetAttribute(const char* attachment, const char* name);
+    MfxAttribute GetAttribute(MfxAttributeAttachment attachment, const char* name);
 	MfxAttribute GetPointAttribute(const char* name);
 	MfxAttribute GetVertexAttribute(const char* name);
 	MfxAttribute GetFaceAttribute(const char* name);
@@ -58,6 +59,7 @@ public:
 	 * for the `attachment` argument.
 	 */
     bool HasAttribute(const char* attachment, const char* name);
+    bool HasAttribute(MfxAttributeAttachment attachment, const char* name);
     bool HasPointAttribute(const char* name);
     bool HasVertexAttribute(const char* name);
     bool HasFaceAttribute(const char* name);
@@ -89,6 +91,12 @@ public:
 	MfxAttribute AddVertexAttribute(const char* name, int componentCount, const char* type, const char* semantic = NULL);
 	MfxAttribute AddFaceAttribute(const char* name, int componentCount, const char* type, const char* semantic = NULL);
 	MfxAttribute AddMeshAttribute(const char* name, int componentCount, const char* type, const char* semantic = NULL);
+
+    MfxAttribute AddAttribute(MfxAttributeAttachment attachment, const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic = MfxAttributeSemantic::None);
+    MfxAttribute AddPointAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic = MfxAttributeSemantic::None);
+    MfxAttribute AddVertexAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic = MfxAttributeSemantic::None);
+    MfxAttribute AddFaceAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic = MfxAttributeSemantic::None);
+    MfxAttribute AddMeshAttribute(const char* name, int componentCount, MfxAttributeType type, MfxAttributeSemantic semantic = MfxAttributeSemantic::None);
 
 	/**
 	 * Allocate memory for new owned attributes according to the previously


### PR DESCRIPTION
While implementing attribute requests to MfxVTK, I found these `MfxAttributeType`-like enums useful, so I added them to the SDK.

I also overloaded existing methods to use these enums. Older methods using `const char*` were kept as-is, but for simplicity/ergonomics they could be removed in the future. In that case, maybe the `mfxAttr*AsString()`, `mfxAttr*AsEnum()` methods should be public, in case the plugins ever need to interact with the C API directly.