### PR TITLE
[sdk] Support range-based for-loop in Collection class in Host SDK

### DIFF
--- a/sdk/cpp/host/src/Collection.h
+++ b/sdk/cpp/host/src/Collection.h
@@ -37,6 +37,31 @@ template<typename T, typename Index = typename T::Index> class Collection {
   Collection() {}
   MOVE_ONLY(Collection)
 
+  class Iterator {
+  public:
+    Iterator(Collection& collection, int index) : m_collection(collection), m_index(index) {}
+
+    Iterator operator++()
+    {
+      m_index++;
+      return *this;
+    }
+
+    bool operator!=(const Iterator &other) const
+    {
+      return m_index != other.m_index;
+    }
+
+    T& operator*() const
+    {
+      return m_collection[this->m_index];
+    }
+
+  private:
+    Collection &m_collection;
+    int m_index;
+  };
+
   int find(const Index &index) const
   {
     int i = -1;
@@ -121,6 +146,16 @@ template<typename T, typename Index = typename T::Index> class Collection {
   const T &operator[](const char *charIndex) const
   {
     (*this)[Index(charIndex)];
+  }
+
+  Iterator begin()
+  {
+    return Iterator(*this, 0);
+  }
+
+  Iterator end()
+  {
+    return Iterator(*this, count());
   }
 
   virtual void onNewItem(T &item)


### PR DESCRIPTION
I've been playing around with the Host C++ SDK regarding the RFC to run plugins in a separate process and noticed that range-based `for` wasn't supported on `OfxPropertySetStruct`, `OfxAttributeSetStruct`, etc. so I added it.